### PR TITLE
untitled docs plugin: fixed to use file template on creation

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -74,6 +74,12 @@ GeanyFilePrefs;
 #define GEANY_TYPE_DOCUMENT (document_get_type())
 GType document_get_type (void);
 
+enum
+{
+	DOCUMENT_CREATION_TYPE_DEFAULT = 0,
+	DOCUMENT_CREATION_TYPE_TEMPLATE
+};
+
 /**
  *  Structure for representing an open tab with all its properties.
  **/
@@ -164,6 +170,9 @@ GeanyDocument;
 
 
 GeanyDocument* document_new_file(const gchar *filename, GeanyFiletype *ft, const gchar *text);
+
+GeanyDocument *document_new_file_with_creation_type(const gchar *utf8_filename, GeanyFiletype *ft,
+		const gchar *text, gint document_creation_type);
 
 GeanyDocument *document_get_current(void);
 

--- a/src/geanyobject.c
+++ b/src/geanyobject.c
@@ -81,9 +81,9 @@ static void create_signals(GObjectClass *g_object_class)
 		"document-new",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
-		G_TYPE_NONE, 1,
-		GEANY_TYPE_DOCUMENT);
+		0, NULL, NULL, NULL,
+		G_TYPE_NONE, 2,
+		G_TYPE_INT, GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_OPEN] = g_signal_new (
 		"document-open",
 		G_OBJECT_CLASS_TYPE (g_object_class),

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -720,6 +720,12 @@ void plugin_set_document_data(struct GeanyPlugin *plugin, struct GeanyDocument *
  *         g_strdup("some-data"), g_free);
  * }
  *
+ * void on_document_new(GObject *unused, gint document_creation_type, GeanyDocument *doc, GeanyPlugin *plugin)
+ * {
+ *     plugin_set_document_data_full(plugin, doc, "my-data",
+ *         g_strdup("some-data"), g_free);
+ * }
+ *
  * void on_document_save(GObject *unused, GeanyDocument *doc, GeanyPlugin *plugin)
  * {
  *     const gchar *some_data = plugin_get_document_data(plugin, doc, "my-data");
@@ -731,7 +737,7 @@ void plugin_set_document_data(struct GeanyPlugin *plugin, struct GeanyDocument *
  *     plugin_signal_connect(plugin, NULL, "document-open", TRUE,
  *         G_CALLBACK(on_document_open), plugin);
  *     plugin_signal_connect(plugin, NULL, "document-new", TRUE,
- *         G_CALLBACK(on_document_open), plugin);
+ *         G_CALLBACK(on_document_new), plugin);
  *     plugin_signal_connect(plugin, NULL, "document-save", TRUE,
  *         G_CALLBACK(on_document_save), plugin);
  *     return TRUE;

--- a/src/templates.c
+++ b/src/templates.c
@@ -225,7 +225,7 @@ on_new_with_file_template(GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer user_dat
 	if (template)
 	{
 		/* line endings will be converted */
-		document_new_file(new_filename, ft, template);
+		document_new_file_with_creation_type(new_filename, ft, template, DOCUMENT_CREATION_TYPE_TEMPLATE);
 	}
 	else
 	{


### PR DESCRIPTION
https://github.com/user-attachments/assets/b4ee0a2f-48ff-4b47-a9fe-0d520f7d77e0

Instantsave, and, by extension, Persistent Untitled Documents are not supporting files, created using templates - though this was initially intended to work (mentioned in docs and there are traces in code).

In order to achieve this we have to somehow tell plugin that it should process "document-new" event even if document already has a name property set (templating code sets it as e.g. "untitled.c" for C template).
This could be achieved in a different ways, but proposed one looks best to me as a balance between breaking changes and simple but crappy fix.
I hope im right that this approach doesnt break any ABI